### PR TITLE
feat: show hostname of running app

### DIFF
--- a/app/attack/page.tsx
+++ b/app/attack/page.tsx
@@ -1,6 +1,5 @@
 import VisitDashboard from "@/components/compositions/VisitDashboard";
 import WhatNext from "@/components/compositions/WhatNext";
-import useSiteKey from "@/components/effects/useSiteKey";
 import Divider from "@/components/elements/Divider";
 import styles from "@/components/elements/PageShared.module.scss";
 import type { Metadata } from "next";
@@ -14,7 +13,7 @@ export const metadata: Metadata = {
 };
 
 export default async function IndexPage() {
-  const { siteKey } = useSiteKey();
+  const siteKey = process.env.ARCJET_SITE ? process.env.ARCJET_SITE : null;
   const headersList = await headers();
   const hostname = headersList.get('host') || 'example.arcjet.com'; // Default to hosted example if undefined
 

--- a/app/attack/page.tsx
+++ b/app/attack/page.tsx
@@ -4,6 +4,7 @@ import useSiteKey from "@/components/effects/useSiteKey";
 import Divider from "@/components/elements/Divider";
 import styles from "@/components/elements/PageShared.module.scss";
 import type { Metadata } from "next";
+import { headers } from 'next/headers';
 import Link from "next/link";
 
 export const metadata: Metadata = {
@@ -12,8 +13,10 @@ export const metadata: Metadata = {
     "An example of Arcjet's attack protection for Next.js. Protect Next.js against SQL injection, cross-site scripting, and other attacks.",
 };
 
-export default function IndexPage() {
+export default async function IndexPage() {
   const { siteKey } = useSiteKey();
+  const headersList = await headers();
+  const hostname = headersList.get('host') || 'example.arcjet.com'; // Default to hosted example if undefined
 
   return (
     <section className={styles.Content}>
@@ -55,7 +58,7 @@ export default function IndexPage() {
         </p>
         <pre className="p-4">
           curl -v -H &quot;x-arcjet-suspicious: true&quot;
-          https://example.arcjet.com/attack/test
+          https://{hostname}/attack/test
         </pre>
         <p className="max-w-[700px] text-secondary-foreground">
           After the 5th request, your IP will be blocked for 15 minutes.

--- a/app/bots/page.tsx
+++ b/app/bots/page.tsx
@@ -1,6 +1,5 @@
 import VisitDashboard from "@/components/compositions/VisitDashboard";
 import WhatNext from "@/components/compositions/WhatNext";
-import useSiteKey from "@/components/effects/useSiteKey";
 import Divider from "@/components/elements/Divider";
 import type { Metadata } from "next";
 import { headers } from 'next/headers';
@@ -14,7 +13,7 @@ export const metadata: Metadata = {
 };
 
 export default async function IndexPage() {
-  const { siteKey } = useSiteKey();
+  const siteKey = process.env.ARCJET_SITE ? process.env.ARCJET_SITE : null;
   const headersList = await headers();
   const hostname = headersList.get('host') || 'example.arcjet.com'; // Default to hosted example if undefined
 

--- a/app/bots/page.tsx
+++ b/app/bots/page.tsx
@@ -3,6 +3,7 @@ import WhatNext from "@/components/compositions/WhatNext";
 import useSiteKey from "@/components/effects/useSiteKey";
 import Divider from "@/components/elements/Divider";
 import type { Metadata } from "next";
+import { headers } from 'next/headers';
 import Link from "next/link";
 
 import styles from "@/components/elements/PageShared.module.scss";
@@ -12,8 +13,10 @@ export const metadata: Metadata = {
   description: "An example of Arcjet's bot protection for Next.js.",
 };
 
-export default function IndexPage() {
+export default async function IndexPage() {
   const { siteKey } = useSiteKey();
+  const headersList = await headers();
+  const hostname = headersList.get('host') || 'example.arcjet.com'; // Default to hosted example if undefined
 
   return (
     <section className={styles.Content}>
@@ -41,7 +44,7 @@ export default function IndexPage() {
           Make a request using <code>curl</code>, which is considered an
           automated client:
         </p>
-        <pre className="p-4">curl -v https://example.arcjet.com/bots/test</pre>
+        <pre className="p-4">curl -v https://{hostname}/bots/test</pre>
         <p className="text-secondary-foreground">
           Your IP will be blocked for 60 seconds.
         </p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,4 @@
 import WhatNext from "@/components/compositions/WhatNext";
-import useSiteKey from "@/components/effects/useSiteKey";
 import Divider from "@/components/elements/Divider";
 import { buttonVariants } from "@/components/ui/button";
 import Link from "next/link";
@@ -7,7 +6,7 @@ import Link from "next/link";
 import styles from "@/components/elements/PageShared.module.scss";
 
 export default function IndexPage() {
-  const { siteKey } = useSiteKey();
+  const siteKey = process.env.ARCJET_SITE ? process.env.ARCJET_SITE : null;
 
   return (
     <section className={styles.Content}>

--- a/app/rate-limiting/page.tsx
+++ b/app/rate-limiting/page.tsx
@@ -1,9 +1,7 @@
 import { RLForm } from "@/components/RLForm";
 import { SignIn } from "@/components/SignIn";
 import { SignOut } from "@/components/SignOut";
-import VisitDashboard from "@/components/compositions/VisitDashboard";
 import WhatNext from "@/components/compositions/WhatNext";
-import useSiteKey from "@/components/effects/useSiteKey";
 import Divider from "@/components/elements/Divider";
 import { auth } from "@/lib/auth";
 import type { Metadata } from "next";

--- a/app/sensitive-info/page.tsx
+++ b/app/sensitive-info/page.tsx
@@ -1,7 +1,6 @@
 import { SupportForm } from "@/components/SuppportForm";
 import VisitDashboard from "@/components/compositions/VisitDashboard";
 import WhatNext from "@/components/compositions/WhatNext";
-import useSiteKey from "@/components/effects/useSiteKey";
 import Divider from "@/components/elements/Divider";
 import styles from "@/components/elements/PageShared.module.scss";
 import type { Metadata } from "next";
@@ -14,7 +13,7 @@ export const metadata: Metadata = {
 };
 
 export default function IndexPage() {
-  const { siteKey } = useSiteKey();
+  const siteKey = process.env.ARCJET_SITE ? process.env.ARCJET_SITE : null;
 
   return (
     <section className={styles.Content}>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,7 +1,6 @@
 import { EmailForm } from "@/components/EmailForm";
 import VisitDashboard from "@/components/compositions/VisitDashboard";
 import WhatNext from "@/components/compositions/WhatNext";
-import useSiteKey from "@/components/effects/useSiteKey";
 import Divider from "@/components/elements/Divider";
 import type { Metadata } from "next";
 import Link from "next/link";
@@ -15,7 +14,7 @@ export const metadata: Metadata = {
 };
 
 export default function IndexPage() {
-  const { siteKey } = useSiteKey();
+  const siteKey = process.env.ARCJET_SITE ? process.env.ARCJET_SITE : null;
 
   return (
     <section className={styles.Content}>


### PR DESCRIPTION
Currently we just hardcode the shield cURL request to hit `example.arcjet.com`.
Instead we should attempt to resolve the hostname that the user is using so that they
hit their own app and it shows up in their logs.
