### PR TITLE
chore: remove next config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,0 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  reactStrictMode: true,
-};
-
-export default nextConfig;


### PR DESCRIPTION
Strict mode is now default: https://nextjs.org/docs/app/api-reference/config/next-config-js/reactStrictMode