### PR TITLE
chore(docs): Remove dead link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,7 @@ server](https://arcjet.com/discord).
 - Auth: [Auth.js](https://authjs.dev/)
 - App: [Next.js](https://nextjs.org/)
 - UI: [shadcn/ui](https://ui.shadcn.com/)
-- Form handling: [React Hook Form](https://react-hook-form.com/) (see also [our
-  full form protection
-  example](https://github.com/arcjet/arcjet-js/tree/main/examples/nextjs-14-react-hook-form))
+- Form handling: [React Hook Form](https://react-hook-form.com/)
 - Client-side validation: [Zod](https://zod.dev/)
 - Security: [Arcjet](https://arcjet.com/)
 


### PR DESCRIPTION
This example no longer seems to exist